### PR TITLE
Fix for test case hang issue

### DIFF
--- a/patches/PR3/test-unsetenv.c.patch
+++ b/patches/PR3/test-unsetenv.c.patch
@@ -1,0 +1,20 @@
+diff --git a/gettext-tools/gnulib-tests/test-unsetenv.c b/gettext-tools/gnulib-tests/test-unsetenv.c
+index f912e79..630c059 100644
+--- a/gettext-tools/gnulib-tests/test-unsetenv.c
++++ b/gettext-tools/gnulib-tests/test-unsetenv.c
+@@ -32,6 +32,7 @@ SIGNATURE_CHECK (unsetenv, int, (char const *));
+ int
+ main (void)
+ {
++#ifndef __MVS__
+   char entry[] = "b=2";
+ 
+   /* Test removal when multiple entries present.  */
+@@ -49,6 +50,7 @@ main (void)
+   errno = 0;
+   ASSERT (unsetenv ("a=b") == -1);
+   ASSERT (errno == EINVAL);
++#endif
+ #if 0
+   /* glibc and gnulib's implementation guarantee this, but POSIX no
+      longer requires it: http://austingroupbugs.net/view.php?id=185  */

--- a/patches/PR3/test-unsetenv.c.patch
+++ b/patches/PR3/test-unsetenv.c.patch
@@ -1,16 +1,19 @@
 diff --git a/gettext-tools/gnulib-tests/test-unsetenv.c b/gettext-tools/gnulib-tests/test-unsetenv.c
-index f912e79..630c059 100644
+index f912e79..7601fa8 100644
 --- a/gettext-tools/gnulib-tests/test-unsetenv.c
 +++ b/gettext-tools/gnulib-tests/test-unsetenv.c
-@@ -32,6 +32,7 @@ SIGNATURE_CHECK (unsetenv, int, (char const *));
+@@ -32,6 +32,10 @@ SIGNATURE_CHECK (unsetenv, int, (char const *));
  int
  main (void)
  {
++ /*The guard is added as a workaround for issue 
++  * https://github.com/ZOSOpenTools/gettextport/issues/15
++  * This guard can be removed once the fix for issue is provided by LE team*/
 +#ifndef __MVS__
    char entry[] = "b=2";
  
    /* Test removal when multiple entries present.  */
-@@ -49,6 +50,7 @@ main (void)
+@@ -49,6 +53,7 @@ main (void)
    errno = 0;
    ASSERT (unsetenv ("a=b") == -1);
    ASSERT (errno == EINVAL);


### PR DESCRIPTION
The test case test-unsetenv.c was hanging indefinitely and build ws not proceeding. Found that the issue is related to putenv/unsetenv in that test case and brought it to notice of LE team 
https://ibm-systems-z.slack.com/archives/C493603M1/p1674717790790289

Until then , the test case is guarded on z/oS systems.